### PR TITLE
[FEAT]: 공지 관련 기능 구현

### DIFF
--- a/src/main/java/depth/mju/festival/domain/item/domain/repository/ItemRepository.java
+++ b/src/main/java/depth/mju/festival/domain/item/domain/repository/ItemRepository.java
@@ -15,7 +15,7 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     @Query(value =
             "SELECT i " +
                     "FROM Item i " +
-                    "WHERE i.category = :category AND i.status = :status AND i.school.id = 1 " +
+                    "WHERE i.category = :category AND i.status = :status " +
                     "ORDER BY i.createdDate DESC")
     List<Item> findByCategoryAndStatusOrderByCreatedDateDesc(Category category, Status status);
 }

--- a/src/main/java/depth/mju/festival/domain/notice/application/NoticeService.java
+++ b/src/main/java/depth/mju/festival/domain/notice/application/NoticeService.java
@@ -90,4 +90,13 @@ public class NoticeService {
         notice.updateStatus(Status.DELETE);
     }
 
+    // 공지 수정
+    @Transactional
+    public void updateNotice(Long noticeId, NoticeReq noticeReq) {
+        Notice notice = noticeRepository.findByIdAndStatus(noticeId, Status.ACTIVE)
+                .orElseThrow(() -> new DefaultException(ErrorCode.NOT_FOUND_ERROR, "유효한 값이 아닙니다."));
+
+        notice.updateTitleAndContent(noticeReq.getTitle(), noticeReq.getContent());
+    }
+
 }

--- a/src/main/java/depth/mju/festival/domain/notice/application/NoticeService.java
+++ b/src/main/java/depth/mju/festival/domain/notice/application/NoticeService.java
@@ -3,7 +3,7 @@ package depth.mju.festival.domain.notice.application;
 import depth.mju.festival.domain.common.Status;
 import depth.mju.festival.domain.notice.domain.Notice;
 import depth.mju.festival.domain.notice.domain.repository.NoticeRepository;
-import depth.mju.festival.domain.notice.dto.request.CreateNoticeReq;
+import depth.mju.festival.domain.notice.dto.request.NoticeReq;
 import depth.mju.festival.domain.notice.dto.response.NoticeRes;
 import depth.mju.festival.domain.school.domain.School;
 import depth.mju.festival.domain.school.domain.repository.SchoolRepository;
@@ -54,12 +54,9 @@ public class NoticeService {
 
     // 공지 상세 조회
     public NoticeRes findNoticeDetail(Long noticeId) {
-        Notice notice = noticeRepository.findById(noticeId)
+        Notice notice = noticeRepository.findByIdAndStatus(noticeId, Status.ACTIVE)
                 .orElseThrow(() -> new DefaultException(ErrorCode.NOT_FOUND_ERROR, "유효한 값이 아닙니다."));
-        // 유효성 검증
-        if (notice.getStatus() == Status.DELETE) {
-            throw new DefaultException(ErrorCode.NOT_VALID_ERROR, "유효한 값이 아닙니다.");
-        }
+
         return NoticeRes.builder()
                 .noticeId(notice.getId())
                 .title(notice.getTitle())
@@ -70,7 +67,7 @@ public class NoticeService {
 
     // 공지 등록
     @Transactional
-    public Notice createNotice(CreateNoticeReq noticeReq) {
+    public Notice createNotice(NoticeReq noticeReq) {
         return Notice.builder()
                 .title(noticeReq.getTitle())
                 .content(noticeReq.getContent())
@@ -93,5 +90,4 @@ public class NoticeService {
         notice.updateStatus(Status.DELETE);
     }
 
-    // 공지 수정
 }

--- a/src/main/java/depth/mju/festival/domain/notice/application/NoticeService.java
+++ b/src/main/java/depth/mju/festival/domain/notice/application/NoticeService.java
@@ -38,7 +38,7 @@ public class NoticeService {
                         .noticeId(notice.getId())
                         .title(notice.getTitle())
                         .content(notice.getContent())
-                        .createdDate(notice.getCreatedDate().toLocalDate())
+                        .createdDate(notice.getCreatedDate())
                         .build())
                 .collect(Collectors.toList());
 

--- a/src/main/java/depth/mju/festival/domain/notice/application/NoticeService.java
+++ b/src/main/java/depth/mju/festival/domain/notice/application/NoticeService.java
@@ -3,7 +3,10 @@ package depth.mju.festival.domain.notice.application;
 import depth.mju.festival.domain.common.Status;
 import depth.mju.festival.domain.notice.domain.Notice;
 import depth.mju.festival.domain.notice.domain.repository.NoticeRepository;
+import depth.mju.festival.domain.notice.dto.request.CreateNoticeReq;
 import depth.mju.festival.domain.notice.dto.response.NoticeRes;
+import depth.mju.festival.domain.school.domain.School;
+import depth.mju.festival.domain.school.domain.repository.SchoolRepository;
 import depth.mju.festival.global.exception.DefaultException;
 import depth.mju.festival.global.exception.ErrorCode;
 import depth.mju.festival.global.response.PageInfo;
@@ -26,6 +29,7 @@ import java.util.stream.Collectors;
 public class NoticeService {
 
     private final NoticeRepository noticeRepository;
+    private final SchoolRepository schoolRepository;
 
     // 공지 조회
     public PageResponse findAllNotice(int page, int size) {
@@ -61,6 +65,20 @@ public class NoticeService {
     }
 
     // 공지 등록
+    @Transactional
+    public Notice createNotice(CreateNoticeReq noticeReq) {
+        return Notice.builder()
+                .title(noticeReq.getTitle())
+                .content(noticeReq.getContent())
+                .school(findDefaultSchool())
+                .build();
+    }
+
+    private School findDefaultSchool() {
+        return schoolRepository.findById(1L)
+                .orElseThrow(() -> new DefaultException(ErrorCode.NOT_FOUND_ERROR, "학교를 찾을 수 없습니다."));
+    }
+
 
     // 공지 삭제
 

--- a/src/main/java/depth/mju/festival/domain/notice/application/NoticeService.java
+++ b/src/main/java/depth/mju/festival/domain/notice/application/NoticeService.java
@@ -56,6 +56,10 @@ public class NoticeService {
     public NoticeRes findNoticeDetail(Long noticeId) {
         Notice notice = noticeRepository.findById(noticeId)
                 .orElseThrow(() -> new DefaultException(ErrorCode.NOT_FOUND_ERROR, "유효한 값이 아닙니다."));
+        // 유효성 검증
+        if (notice.getStatus() == Status.DELETE) {
+            throw new DefaultException(ErrorCode.NOT_VALID_ERROR, "유효한 값이 아닙니다.");
+        }
         return NoticeRes.builder()
                 .noticeId(notice.getId())
                 .title(notice.getTitle())

--- a/src/main/java/depth/mju/festival/domain/notice/application/NoticeService.java
+++ b/src/main/java/depth/mju/festival/domain/notice/application/NoticeService.java
@@ -1,0 +1,56 @@
+package depth.mju.festival.domain.notice.application;
+
+import depth.mju.festival.domain.common.Status;
+import depth.mju.festival.domain.notice.domain.Notice;
+import depth.mju.festival.domain.notice.domain.repository.NoticeRepository;
+import depth.mju.festival.domain.notice.dto.response.NoticeRes;
+import depth.mju.festival.global.response.PageInfo;
+import depth.mju.festival.global.response.PageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NoticeService {
+
+    private final NoticeRepository noticeRepository;
+
+    // 공지 조회
+    public PageResponse findAllNotice(int page, int size) {
+        String sortBy = "createdDate";
+        Sort.Direction direction = Sort.Direction.DESC;
+
+        Pageable pageable = PageRequest.of(page - 1, size, direction, sortBy);
+        Page<Notice> noticePage = noticeRepository.findByStatus(Status.ACTIVE, pageable);
+
+        List<NoticeRes> noticeRes = noticePage.stream()
+                .map(notice -> NoticeRes.builder()
+                        .noticeId(notice.getId())
+                        .title(notice.getTitle())
+                        .content(notice.getContent())
+                        .createdDate(notice.getCreatedDate().toLocalDate())
+                        .build())
+                .collect(Collectors.toList());
+
+        PageInfo pageInfo = PageInfo.toPageInfo(pageable, noticePage);
+        return PageResponse.toPageResponse(pageInfo, noticeRes);
+    }
+
+    // 공지 상세 조회
+
+    // 공지 등록
+
+    // 공지 삭제
+
+    // 공지 수정
+}

--- a/src/main/java/depth/mju/festival/domain/notice/application/NoticeService.java
+++ b/src/main/java/depth/mju/festival/domain/notice/application/NoticeService.java
@@ -4,6 +4,8 @@ import depth.mju.festival.domain.common.Status;
 import depth.mju.festival.domain.notice.domain.Notice;
 import depth.mju.festival.domain.notice.domain.repository.NoticeRepository;
 import depth.mju.festival.domain.notice.dto.response.NoticeRes;
+import depth.mju.festival.global.exception.DefaultException;
+import depth.mju.festival.global.exception.ErrorCode;
 import depth.mju.festival.global.response.PageInfo;
 import depth.mju.festival.global.response.PageResponse;
 import lombok.RequiredArgsConstructor;
@@ -47,6 +49,16 @@ public class NoticeService {
     }
 
     // 공지 상세 조회
+    public NoticeRes findNoticeDetail(Long noticeId) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new DefaultException(ErrorCode.NOT_FOUND_ERROR, "유효한 값이 아닙니다."));
+        return NoticeRes.builder()
+                .noticeId(notice.getId())
+                .title(notice.getTitle())
+                .content(notice.getContent())
+                .createdDate(notice.getCreatedDate())
+                .build();
+    }
 
     // 공지 등록
 

--- a/src/main/java/depth/mju/festival/domain/notice/application/NoticeService.java
+++ b/src/main/java/depth/mju/festival/domain/notice/application/NoticeService.java
@@ -85,6 +85,13 @@ public class NoticeService {
 
 
     // 공지 삭제
+    @Transactional
+    public void deleteNotice(Long noticeId){
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new DefaultException(ErrorCode.NOT_FOUND_ERROR, "유효한 값이 아닙니다."));
+        // SOFT DELETE
+        notice.updateStatus(Status.DELETE);
+    }
 
     // 공지 수정
 }

--- a/src/main/java/depth/mju/festival/domain/notice/domain/Notice.java
+++ b/src/main/java/depth/mju/festival/domain/notice/domain/Notice.java
@@ -34,4 +34,9 @@ public class Notice extends BaseEntity {
         this.school = school;
     }
 
+    public void updateTitleAndContent(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+
 }

--- a/src/main/java/depth/mju/festival/domain/notice/domain/repository/NoticeRepository.java
+++ b/src/main/java/depth/mju/festival/domain/notice/domain/repository/NoticeRepository.java
@@ -7,7 +7,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
     Page<Notice> findByStatus(Status status, Pageable pageable);
+
+    Optional<Notice> findByIdAndStatus(Long noticeId, Status status);
 }

--- a/src/main/java/depth/mju/festival/domain/notice/domain/repository/NoticeRepository.java
+++ b/src/main/java/depth/mju/festival/domain/notice/domain/repository/NoticeRepository.java
@@ -1,0 +1,13 @@
+package depth.mju.festival.domain.notice.domain.repository;
+
+import depth.mju.festival.domain.common.Status;
+import depth.mju.festival.domain.notice.domain.Notice;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+    Page<Notice> findByStatus(Status status, Pageable pageable);
+}

--- a/src/main/java/depth/mju/festival/domain/notice/dto/request/CreateNoticeReq.java
+++ b/src/main/java/depth/mju/festival/domain/notice/dto/request/CreateNoticeReq.java
@@ -1,0 +1,18 @@
+package depth.mju.festival.domain.notice.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class CreateNoticeReq {
+
+    @NotBlank
+    @Schema(type = "String", example = "[공지사항] 2024 축제 안내", description = "공지의 내용입니다.")
+    private String title;
+
+    @NotBlank
+    @Schema(type = "String", example = "축제 일정은 10월 7일 월요일부터 8일 화요일까지이며...", description = "공지의 내용입니다.")
+    private String content;
+
+}

--- a/src/main/java/depth/mju/festival/domain/notice/dto/request/NoticeReq.java
+++ b/src/main/java/depth/mju/festival/domain/notice/dto/request/NoticeReq.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
-public class CreateNoticeReq {
+public class NoticeReq {
 
     @NotBlank
     @Schema(type = "String", example = "[공지사항] 2024 축제 안내", description = "공지의 내용입니다.")

--- a/src/main/java/depth/mju/festival/domain/notice/dto/response/NoticeRes.java
+++ b/src/main/java/depth/mju/festival/domain/notice/dto/response/NoticeRes.java
@@ -1,0 +1,36 @@
+package depth.mju.festival.domain.notice.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class NoticeRes {
+
+    @Schema(type = "Long", example = "1", description = "공지의 id입니다.")
+    private Long noticeId;
+
+    @Schema(type = "String", example = "[공지사항] 2024 축제 안내", description = "공지의 내용입니다.")
+    private String title;
+
+    @Schema(type = "String", example = "축제 일정은 10월 7일 월요일부터 8일 화요일까지이며...", description = "공지의 내용입니다.")
+    private String content;
+
+    @Schema(type = "LocalDate", example = "2024-04-26", description = "공지의 작성일입니다.")
+    @JsonFormat(pattern = "yyyy-MM-dd", shape = JsonFormat.Shape.STRING)
+    private LocalDate createdDate;
+
+    @Builder
+    public NoticeRes(Long noticeId, String title, String content, LocalDate createdDate) {
+        this.noticeId = noticeId;
+        this.title = title;
+        this.content = content;
+        this.createdDate = createdDate;
+    }
+
+}

--- a/src/main/java/depth/mju/festival/domain/notice/dto/response/NoticeRes.java
+++ b/src/main/java/depth/mju/festival/domain/notice/dto/response/NoticeRes.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor
@@ -21,12 +22,12 @@ public class NoticeRes {
     @Schema(type = "String", example = "축제 일정은 10월 7일 월요일부터 8일 화요일까지이며...", description = "공지의 내용입니다.")
     private String content;
 
-    @Schema(type = "LocalDate", example = "2024-04-26", description = "공지의 작성일입니다.")
-    @JsonFormat(pattern = "yyyy-MM-dd", shape = JsonFormat.Shape.STRING)
-    private LocalDate createdDate;
+    @Schema(type = "LocalDate", example = "2024-04-26 10:24", description = "공지의 작성일시입니다.")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm", shape = JsonFormat.Shape.STRING)
+    private LocalDateTime createdDate;
 
     @Builder
-    public NoticeRes(Long noticeId, String title, String content, LocalDate createdDate) {
+    public NoticeRes(Long noticeId, String title, String content, LocalDateTime createdDate) {
         this.noticeId = noticeId;
         this.title = title;
         this.content = content;

--- a/src/main/java/depth/mju/festival/domain/notice/presentation/NoticeApi.java
+++ b/src/main/java/depth/mju/festival/domain/notice/presentation/NoticeApi.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "공지사항 API", description = "공지사항과 관련한 API입니다.")
@@ -38,5 +39,20 @@ public interface NoticeApi {
     ResponseEntity<depth.mju.festival.global.response.ApiResponse> findNotices(
             @Parameter(description = "페이지의 번호를 입력해주세요. 기본값은 1이며 페이지는 1부터 시작합니다.", required = true) @RequestParam(defaultValue = "1") int page,
             @Parameter(description = "페이지 내 요소의 개수입니다. 기본값은 6입니다.") @RequestParam(defaultValue = "6") int size
+    );
+
+    @Operation(summary = "공지사항 상세 조회", description = "공지사항을 상세 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "공지사항 상세 조회 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = NoticeRes.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "조회 실패",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+    })
+    @GetMapping("/{noticeId}")
+    ResponseEntity<depth.mju.festival.global.response.ApiResponse> findNoticeDetail(
+            @Parameter(description = "공지사항의 id를 입력해주세요.", required = true) @PathVariable Long noticeId
     );
 }

--- a/src/main/java/depth/mju/festival/domain/notice/presentation/NoticeApi.java
+++ b/src/main/java/depth/mju/festival/domain/notice/presentation/NoticeApi.java
@@ -1,8 +1,6 @@
 package depth.mju.festival.domain.notice.presentation;
 
-import depth.mju.festival.domain.item.domain.Category;
-import depth.mju.festival.domain.item.dto.response.ItemRes;
-import depth.mju.festival.domain.notice.dto.request.CreateNoticeReq;
+import depth.mju.festival.domain.notice.dto.request.NoticeReq;
 import depth.mju.festival.domain.notice.dto.response.NoticeRes;
 import depth.mju.festival.global.exception.ErrorResponse;
 import depth.mju.festival.global.response.PageResponse;
@@ -68,7 +66,7 @@ public interface NoticeApi {
     })
     @PostMapping
     ResponseEntity<Void> registerNotice(
-            @Parameter(description = "Schemas의 CreateNoticeReq를 참고해주세요.", required = true) @Valid @RequestBody CreateNoticeReq createNoticeReq
+            @Parameter(description = "Schemas의 NoticeReq를 참고해주세요.", required = true) @Valid @RequestBody NoticeReq noticeReq
     );
 
     @Operation(summary = "공지사항 삭제", description = "공지사항을 삭제합니다.")
@@ -81,8 +79,24 @@ public interface NoticeApi {
                     responseCode = "400", description = "삭제 실패",
                     content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
     })
-    @GetMapping("/{noticeId}")
+    @DeleteMapping("/{noticeId}")
     ResponseEntity<Void> deleteNotice(
             @Parameter(description = "공지사항의 id를 입력해주세요.", required = true) @PathVariable Long noticeId
+    );
+
+    @Operation(summary = "공지사항 수정", description = "공지사항을 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "204", description = "수정 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = Void.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "수정 실패",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+    })
+    @PutMapping("/{noticeId}")
+    ResponseEntity<Void> modifyNotice(
+            @Parameter(description = "공지사항의 id를 입력해주세요.", required = true) @PathVariable Long noticeId,
+            @Parameter(description = "Schemas의 NoticeReq를 참고해주세요.", required = true) @Valid @RequestBody NoticeReq noticeReq
     );
 }

--- a/src/main/java/depth/mju/festival/domain/notice/presentation/NoticeApi.java
+++ b/src/main/java/depth/mju/festival/domain/notice/presentation/NoticeApi.java
@@ -1,0 +1,42 @@
+package depth.mju.festival.domain.notice.presentation;
+
+import depth.mju.festival.domain.item.domain.Category;
+import depth.mju.festival.domain.item.dto.response.ItemRes;
+import depth.mju.festival.domain.notice.dto.response.NoticeRes;
+import depth.mju.festival.global.exception.ErrorResponse;
+import depth.mju.festival.global.response.PageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "공지사항 API", description = "공지사항과 관련한 API입니다.")
+public interface NoticeApi {
+
+    @Operation(summary = "공지사항 목록 조회", description = "공지사항을 목록으로 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "0", description = "공지사항 목록 조회 성공 - dataList 구성",
+                    content = {@Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = NoticeRes.class)))}
+            ),
+            @ApiResponse(
+                    responseCode = "200", description = "공지사항 목록 조회 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = PageResponse.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "조회 실패",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+    })
+    @GetMapping
+    ResponseEntity<depth.mju.festival.global.response.ApiResponse> findNotices(
+            @Parameter(description = "페이지의 번호를 입력해주세요. 기본값은 1이며 페이지는 1부터 시작합니다.", required = true) @RequestParam(defaultValue = "1") int page,
+            @Parameter(description = "페이지 내 요소의 개수입니다. 기본값은 6입니다.") @RequestParam(defaultValue = "6") int size
+    );
+}

--- a/src/main/java/depth/mju/festival/domain/notice/presentation/NoticeApi.java
+++ b/src/main/java/depth/mju/festival/domain/notice/presentation/NoticeApi.java
@@ -2,6 +2,7 @@ package depth.mju.festival.domain.notice.presentation;
 
 import depth.mju.festival.domain.item.domain.Category;
 import depth.mju.festival.domain.item.dto.response.ItemRes;
+import depth.mju.festival.domain.notice.dto.request.CreateNoticeReq;
 import depth.mju.festival.domain.notice.dto.response.NoticeRes;
 import depth.mju.festival.global.exception.ErrorResponse;
 import depth.mju.festival.global.response.PageResponse;
@@ -13,10 +14,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "공지사항 API", description = "공지사항과 관련한 API입니다.")
 public interface NoticeApi {
@@ -53,6 +53,36 @@ public interface NoticeApi {
     })
     @GetMapping("/{noticeId}")
     ResponseEntity<depth.mju.festival.global.response.ApiResponse> findNoticeDetail(
+            @Parameter(description = "공지사항의 id를 입력해주세요.", required = true) @PathVariable Long noticeId
+    );
+
+    @Operation(summary = "공지사항 등록", description = "공지사항을 등록합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201", description = "등록 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = Void.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "등록 실패",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+    })
+    @PostMapping
+    ResponseEntity<Void> registerNotice(
+            @Parameter(description = "Schemas의 CreateNoticeReq를 참고해주세요.", required = true) @Valid @RequestBody CreateNoticeReq createNoticeReq
+    );
+
+    @Operation(summary = "공지사항 삭제", description = "공지사항을 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "204", description = "삭제 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = Void.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "삭제 실패",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+    })
+    @GetMapping("/{noticeId}")
+    ResponseEntity<Void> deleteNotice(
             @Parameter(description = "공지사항의 id를 입력해주세요.", required = true) @PathVariable Long noticeId
     );
 }

--- a/src/main/java/depth/mju/festival/domain/notice/presentation/NoticeController.java
+++ b/src/main/java/depth/mju/festival/domain/notice/presentation/NoticeController.java
@@ -4,10 +4,7 @@ import depth.mju.festival.domain.notice.application.NoticeService;
 import depth.mju.festival.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -24,6 +21,17 @@ public class NoticeController {
         ApiResponse apiResponse = ApiResponse.builder()
                 .check(true)
                 .information(noticeService.findAllNotice(page, size))
+                .build();
+        return ResponseEntity.ok(apiResponse);
+    }
+
+    @GetMapping("/{noticeId}")
+    public ResponseEntity<ApiResponse> findNoticeDetail(
+            @PathVariable Long noticeId
+    ) {
+        ApiResponse apiResponse = ApiResponse.builder()
+                .check(true)
+                .information(noticeService.findNoticeDetail(noticeId))
                 .build();
         return ResponseEntity.ok(apiResponse);
     }

--- a/src/main/java/depth/mju/festival/domain/notice/presentation/NoticeController.java
+++ b/src/main/java/depth/mju/festival/domain/notice/presentation/NoticeController.java
@@ -1,10 +1,15 @@
 package depth.mju.festival.domain.notice.presentation;
 
 import depth.mju.festival.domain.notice.application.NoticeService;
+import depth.mju.festival.domain.notice.domain.Notice;
+import depth.mju.festival.domain.notice.dto.request.CreateNoticeReq;
 import depth.mju.festival.global.response.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
 
 @RequiredArgsConstructor
 @RestController
@@ -34,5 +39,13 @@ public class NoticeController {
                 .information(noticeService.findNoticeDetail(noticeId))
                 .build();
         return ResponseEntity.ok(apiResponse);
+    }
+
+    @PostMapping()
+    public ResponseEntity<Void> registerNotice(
+            @Valid @RequestBody CreateNoticeReq createNoticeReq
+    ) {
+        Notice notice = noticeService.createNotice(createNoticeReq);
+        return ResponseEntity.created(URI.create("/api/v1/notices" + notice.getId())).build();
     }
 }

--- a/src/main/java/depth/mju/festival/domain/notice/presentation/NoticeController.java
+++ b/src/main/java/depth/mju/festival/domain/notice/presentation/NoticeController.java
@@ -2,7 +2,7 @@ package depth.mju.festival.domain.notice.presentation;
 
 import depth.mju.festival.domain.notice.application.NoticeService;
 import depth.mju.festival.domain.notice.domain.Notice;
-import depth.mju.festival.domain.notice.dto.request.CreateNoticeReq;
+import depth.mju.festival.domain.notice.dto.request.NoticeReq;
 import depth.mju.festival.global.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -46,9 +46,9 @@ public class NoticeController implements NoticeApi {
     @Override
     @PostMapping()
     public ResponseEntity<Void> registerNotice(
-            @Valid @RequestBody CreateNoticeReq createNoticeReq
+            @Valid @RequestBody NoticeReq noticeReq
     ) {
-        Notice notice = noticeService.createNotice(createNoticeReq);
+        Notice notice = noticeService.createNotice(noticeReq);
         return ResponseEntity.created(URI.create("/api/v1/notices" + notice.getId())).build();
     }
 
@@ -58,6 +58,16 @@ public class NoticeController implements NoticeApi {
             @PathVariable Long noticeId
     ) {
         noticeService.deleteNotice(noticeId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    @PutMapping("/{noticeId}")
+    public ResponseEntity<Void> modifyNotice(
+            @PathVariable Long noticeId,
+            @Valid @RequestBody NoticeReq noticeReq
+    ) {
+        noticeService.updateNotice(noticeId, noticeReq);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/depth/mju/festival/domain/notice/presentation/NoticeController.java
+++ b/src/main/java/depth/mju/festival/domain/notice/presentation/NoticeController.java
@@ -14,10 +14,11 @@ import java.net.URI;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1/notices")
-public class NoticeController {
+public class NoticeController implements NoticeApi {
 
     private final NoticeService noticeService;
 
+    @Override
     @GetMapping
     public ResponseEntity<ApiResponse> findNotices(
             @RequestParam(defaultValue = "1") int page,
@@ -30,6 +31,7 @@ public class NoticeController {
         return ResponseEntity.ok(apiResponse);
     }
 
+    @Override
     @GetMapping("/{noticeId}")
     public ResponseEntity<ApiResponse> findNoticeDetail(
             @PathVariable Long noticeId
@@ -41,11 +43,21 @@ public class NoticeController {
         return ResponseEntity.ok(apiResponse);
     }
 
+    @Override
     @PostMapping()
     public ResponseEntity<Void> registerNotice(
             @Valid @RequestBody CreateNoticeReq createNoticeReq
     ) {
         Notice notice = noticeService.createNotice(createNoticeReq);
         return ResponseEntity.created(URI.create("/api/v1/notices" + notice.getId())).build();
+    }
+
+    @Override
+    @DeleteMapping("/{noticeId}")
+    public ResponseEntity<Void> deleteNotice(
+            @PathVariable Long noticeId
+    ) {
+        noticeService.deleteNotice(noticeId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/depth/mju/festival/domain/notice/presentation/NoticeController.java
+++ b/src/main/java/depth/mju/festival/domain/notice/presentation/NoticeController.java
@@ -1,0 +1,30 @@
+package depth.mju.festival.domain.notice.presentation;
+
+import depth.mju.festival.domain.notice.application.NoticeService;
+import depth.mju.festival.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/notices")
+public class NoticeController {
+
+    private final NoticeService noticeService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse> findNotices(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "6") int size
+    ) {
+        ApiResponse apiResponse = ApiResponse.builder()
+                .check(true)
+                .information(noticeService.findAllNotice(page, size))
+                .build();
+        return ResponseEntity.ok(apiResponse);
+    }
+}

--- a/src/main/java/depth/mju/festival/domain/school/domain/repository/SchoolRepository.java
+++ b/src/main/java/depth/mju/festival/domain/school/domain/repository/SchoolRepository.java
@@ -1,0 +1,11 @@
+package depth.mju.festival.domain.school.domain.repository;
+
+import depth.mju.festival.domain.school.domain.School;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SchoolRepository extends JpaRepository<School, Long> {
+
+
+}

--- a/src/main/java/depth/mju/festival/global/response/PageInfo.java
+++ b/src/main/java/depth/mju/festival/global/response/PageInfo.java
@@ -23,14 +23,22 @@ public class PageInfo {
     @Schema(type = "Long", example = "33", description = "전체 요소 개수")
     private Long totalElements;
 
+    @Schema(type = "boolean", example = "true", description = "다음 페이지의 존재 여부")
+    private boolean hasNext;
+
+    @Schema(type = "boolean", example = "true", description = "시작페이지 여부")
+    private boolean isFirst;
+
     public PageInfo(){};
 
     @Builder
-    public PageInfo(Integer currentPage, Integer totalPage, Integer pageSize, Long totalElements) {
+    public PageInfo(Integer currentPage, Integer totalPage, Integer pageSize, Long totalElements, boolean hasNext, boolean isFirst) {
         this.currentPage = currentPage;
         this.totalPage = totalPage;
         this.pageSize = pageSize;
         this.totalElements = totalElements;
+        this.hasNext = hasNext;
+        this.isFirst = isFirst;
     }
 
     public static PageInfo toPageInfo(Pageable pageable, Page<?> pageContent) {
@@ -39,6 +47,8 @@ public class PageInfo {
                 .totalPage(pageContent.getTotalPages())
                 .pageSize(pageable.getPageSize())
                 .totalElements(pageContent.getTotalElements())
+                .hasNext(pageContent.hasNext())
+                .isFirst(pageContent.isFirst())
                 .build();
     }
 }


### PR DESCRIPTION
## ✨ Description
공지 관련 기능 전체 구현


## ☀️ Feature
- [x] 공지 목록 조회
- [x] 공지 상세 조회
- [x] 공지 수정
- [x] 공지 삭제
- [x] 공지 등록 


## ✅ Issue
resolve #3 


## 📢 Comment
- 공지 삭제 `SOFT DELETE` 구현, 조회 시 `Status.ACTIVE` 조건 부여
> `school` 테이블 생성하여 `notice`, `item`과 연결하긴 했으나 고민할 필요가 있음.
- 이전 PR의 해당 내용 관련 수정 사항: 조회 시 school 조건 제외
    - 이용 학교는 명지대학교 인문캠퍼스 하나
    - 또한 불필요한 조건으로 성능에 영향이 미치는 일 배제 
- 공지 목록 조회 시 페이지네이션 처리


## 💡References
-

